### PR TITLE
Update versioning utility

### DIFF
--- a/dist/useFilesField.js
+++ b/dist/useFilesField.js
@@ -46,12 +46,11 @@ var useFilesField = function useFilesField(name, onFileLoad) {
     var target = _ref.target;
     var nameList = meta.data.NAME_LIST;
     Array.from(target.files).forEach(function (file) {
-      var filename = file.name;
+      var filename = file.name; // add a verion number for repeated file names
 
-      if (nameList.includes(filename)) {
-        var count = nameList.reduce(function (n, val) {
-          return n + (val === file.name);
-        }, 0);
+      var count = (0, _utils.countDuplicates)(nameList, filename);
+
+      if (count) {
         filename = (0, _utils.addVersionToFilename)(filename, count);
       }
 

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -3,12 +3,39 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.addVersionToFilename = void 0;
+exports.addVersionToFilename = exports.countDuplicates = void 0;
+
+var countDuplicates = function countDuplicates(array, value) {
+  var name = value.substring(0, value.lastIndexOf("."));
+  var extension = value.split(".").pop();
+  var pattern;
+
+  if (name) {
+    pattern = "".concat(name, "(\\(\\d+\\))?\\.").concat(extension);
+  } else {
+    pattern = "".concat(extension, "(\\(\\d+\\))?");
+  }
+
+  var count = 0;
+  array.forEach(function (item) {
+    if (item.match(pattern)) {
+      count += 1;
+    }
+  });
+  return count;
+};
+
+exports.countDuplicates = countDuplicates;
 
 var addVersionToFilename = function addVersionToFilename(filename, version) {
   var name = filename.substring(0, filename.lastIndexOf("."));
   var extension = filename.split(".").pop();
-  return "".concat(name, "(").concat(version, ").").concat(extension);
+
+  if (name) {
+    return "".concat(name, "(").concat(version, ").").concat(extension);
+  }
+
+  return "".concat(extension, "(").concat(version, ")");
 };
 
 exports.addVersionToFilename = addVersionToFilename;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-final-form-file-field",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Easy add a file upload field to your final-form form.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/useFilesField.js
+++ b/src/useFilesField.js
@@ -1,7 +1,7 @@
 import { useRef } from "react";
 import { useFieldArray } from "react-final-form-named-arrays";
 
-import { addVersionToFilename } from "./utils";
+import { addVersionToFilename, countDuplicates } from "./utils";
 
 const defaultConfig = {
 	multiple: true,
@@ -21,11 +21,9 @@ const useFilesField = function (name, onFileLoad, config = {}) {
 		const nameList = meta.data.NAME_LIST;
 		Array.from(target.files).forEach((file) => {
 			var filename = file.name;
-			if (nameList.includes(filename)) {
-				const count = nameList.reduce(
-					(n, val) => n + (val === file.name),
-					0
-				);
+			// add a verion number for repeated file names
+			const count = countDuplicates(nameList, filename);
+			if (duplicates) {
 				filename = addVersionToFilename(filename, count);
 			}
 			onFileLoad({

--- a/src/useFilesField.js
+++ b/src/useFilesField.js
@@ -23,7 +23,7 @@ const useFilesField = function (name, onFileLoad, config = {}) {
 			var filename = file.name;
 			// add a verion number for repeated file names
 			const count = countDuplicates(nameList, filename);
-			if (duplicates) {
+			if (count) {
 				filename = addVersionToFilename(filename, count);
 			}
 			onFileLoad({

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,26 @@
+export const countDuplicates = (array, value) => {
+	const name = value.substring(0, value.lastIndexOf("."));
+	const extension = value.split(".").pop();
+	var pattern;
+	if (name) {
+		pattern = `${name}(\\(\\d+\\))?\\.${extension}`;
+	} else {
+		pattern = `${extension}(\\(\\d+\\))?`;
+	}
+	var count = 0;
+	array.forEach((item) => {
+		if (item.match(pattern)) {
+			count += 1;
+		}
+	});
+	return count;
+};
+
 export const addVersionToFilename = (filename, version) => {
 	const name = filename.substring(0, filename.lastIndexOf("."));
 	const extension = filename.split(".").pop();
-	return `${name}(${version}).${extension}`;
+	if (name) {
+		return `${name}(${version}).${extension}`;
+	}
+	return `${extension}(${version})`;
 };

--- a/tests/FilesField.test.js
+++ b/tests/FilesField.test.js
@@ -9,7 +9,11 @@ describe("FilesField", () => {
 		const mockOnFileLoad = jest.fn();
 		const { container } = render(
 			<FormTemplate>
-				<FilesField name="files" onFileLoad={mockOnFileLoad} />
+				<FilesField
+					id="files"
+					name="files"
+					onFileLoad={mockOnFileLoad}
+				/>
 			</FormTemplate>
 		);
 	});

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,7 +1,20 @@
-import { addVersionToFilename } from "../src/utils";
+import { addVersionToFilename, countDuplicates } from "../src/utils";
+
+describe("countDuplicates", () => {
+	test.each([
+		[["foo", "bar"], "foo", 1],
+		[["foo", "foo(1)", "foo(2)", "bar"], "foo", 3],
+		[["foo.pdf", "bar"], "foo.pdf", 1],
+		[["foo.pdf", "foo(1).pdf", "bar"], "foo.pdf", 2],
+		[["foo3.pdf", "bar"], "foo.pdf", 0],
+	])(`(%s, %i) => %s`, (array, value, expected) => {
+		expect(countDuplicates(array, value)).toEqual(expected);
+	});
+});
 
 describe("addVersionToFilename", () => {
 	test.each([
+		["foo", 52, "foo(52)"],
 		["foo.bar", 2, "foo(2).bar"],
 		["foo.bar.bar", 3, "foo.bar(3).bar"],
 	])(`(%s, %i) => %s`, (filename, version, expected) => {


### PR DESCRIPTION
When multiple files are added with the same name `react-final-form-file-field` appends a version number so that they are distinguishable. 

Currently, this doesn't work correctly. Since it only searches for values exactly equal to the file to be added, not values which already have a version added e.g. in the list ["foo", "foo(1)", "foo(2)", "bar"] it currently only finds one value "foo", not 3.

This PR fixes this, and also bumps the patch version.